### PR TITLE
Remove upload storage acc connection string in gh action

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -24,7 +24,6 @@ jobs:
     secrets:
       RegistryUsername: ${{ secrets.ROBOTICS_AURORAPRODACR_USERNAME }}
       RegistryPassword: ${{ secrets.ROBOTICS_AURORAPRODACR_PASSWORD }}
-      UPLOAD_STORAGE_CONNECTION_STRING: ${{ secrets.UPLOAD_STORAGE_CONNECTION_STRING }}
 
   deploy:
     name: Update deployment in Staging


### PR DESCRIPTION
Remove seemingly unused secret passed to publish component from deploy to staging gh action