### PR TITLE
Bump minimum python version to 3.14

### DIFF
--- a/.github/workflows/test_and_lint_python_package.yml
+++ b/.github/workflows/test_and_lint_python_package.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
     with:
-      python-versions: '["3.13"]'
+      python-versions: '["3.14"]'
       run-black: true
       run-mypy: true
       run-ruff: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sara-thermal-reading"
 version = "0.1.0"
 description = "Sara Thermal Reading"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 dependencies = [
     "python-dotenv",
     "Pillow",


### PR DESCRIPTION
## Summary
- Bump `requires-python` to `>=3.14`
- Update CI to test on Python 3.14 only
- Update Dockerfile to `python:3.14-slim`
- Add `AGENTS.md` to `.gitignore`