### PR TITLE
Add venv to PATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 COPY . .
 
+ENV PATH="/app/.venv/bin:$PATH"
+
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- Add `ENV PATH="/app/.venv/bin:$PATH"` so `CMD ["python", "main.py"]` uses the uv-managed venv python instead of the base image python
- Without this, the container starts with the system python which doesn't have the installed packages