### PR TITLE
Adopt generic CLI contract

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,17 +1,20 @@
-import json
 import logging
 
 import typer
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
+from pydantic import BaseModel, ConfigDict, Field
 
+from sara_thermal_reading.cli_inputs import (
+    parse_extras,
+    parse_input_blob_storage_locations,
+    parse_output_blob_storage_location,
+)
 from sara_thermal_reading.config.logger import setup_logger
 from sara_thermal_reading.config.open_telemetry import setup_open_telemetry
 from sara_thermal_reading.config.settings import settings
-from sara_thermal_reading.main_thermal_workflow import (
-    BlobStorageLocation,
-    run_thermal_reading_workflow,
-)
+from sara_thermal_reading.main_thermal_workflow import run_thermal_reading_workflow
+from sara_thermal_reading.models.blob_storage_location import BlobStorageLocation
 
 setup_logger()
 logger = logging.getLogger(__name__)
@@ -19,46 +22,56 @@ setup_open_telemetry()
 tracer = trace.get_tracer(settings.OTEL_SERVICE_NAME)
 
 
+class ExtrasModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    reference_image_blob_storage_location: BlobStorageLocation = Field(
+        ..., alias="referenceImageBlobStorageLocation"
+    )
+    reference_polygon_blob_storage_location: BlobStorageLocation = Field(
+        ..., alias="referencePolygonBlobStorageLocation"
+    )
+
+
 app = typer.Typer()
 
 
 @app.command()
 def run_thermal_reading(
-    anonymized_blob_storage_location: str = typer.Option(
-        ..., help="JSON string for anonymized data blob storage location"
+    input_blob_storage_locations: str = typer.Option(
+        ...,
+        help=(
+            "JSON array of blob locations to analyze. sara-thermal-reading "
+            "is a single-image analyzer, so the array must contain exactly "
+            "one entry."
+        ),
     ),
-    visualized_blob_storage_location: str = typer.Option(
-        ..., help="JSON string for visualized data blob storage location"
+    output_blob_storage_location: str = typer.Option(
+        ...,
+        help="JSON object describing the destination blob for the visualized image.",
     ),
-    reference_image_blob_storage_location: str = typer.Option(
-        ..., help="JSON string for reference image blob storage location"
-    ),
-    reference_polygon_blob_storage_location: str = typer.Option(
-        ..., help="JSON string for reference polygon blob storage location"
+    extras: str = typer.Option(
+        ...,
+        help=(
+            "JSON object with extra per-workflow parameters. For "
+            "sara-thermal-reading, must contain "
+            "'referenceImageBlobStorageLocation' and "
+            "'referencePolygonBlobStorageLocation'."
+        ),
     ),
     temperature_output_file: str = typer.Option(
         "/tmp/temperature_output.txt", help="Temperature output file path"
     ),
 ) -> None:
-    try:
-        anonymized_location = BlobStorageLocation.model_validate(
-            json.loads(anonymized_blob_storage_location)
-        )
-        visualized_location = BlobStorageLocation.model_validate(
-            json.loads(visualized_blob_storage_location)
-        )
-        reference_image_location = BlobStorageLocation.model_validate(
-            json.loads(reference_image_blob_storage_location)
-        )
-        reference_polygon_location = BlobStorageLocation.model_validate(
-            json.loads(reference_polygon_blob_storage_location)
-        )
-    except json.JSONDecodeError as e:
-        logger.error(f"Invalid JSON provided: {e}")
-        raise typer.Exit(code=1)
-    except Exception as e:
-        logger.error(f"Error parsing input: {e}")
-        raise typer.Exit(code=1)
+    anonymized_location = parse_input_blob_storage_locations(
+        input_blob_storage_locations
+    )[0]
+    visualized_location = parse_output_blob_storage_location(
+        output_blob_storage_location
+    )
+    parsed_extras = parse_extras(extras, ExtrasModel)
+    reference_image_location = parsed_extras.reference_image_blob_storage_location
+    reference_polygon_location = parsed_extras.reference_polygon_blob_storage_location
 
     with tracer.start_as_current_span(
         "cli.run",

--- a/sara_thermal_reading/cli_inputs.py
+++ b/sara_thermal_reading/cli_inputs.py
@@ -1,0 +1,90 @@
+"""Typer callbacks for parsing the generic SARA blob-location CLI contract.
+
+SARA invokes analyzer images with three JSON-encoded options:
+
+* ``--input-blob-storage-locations``  -- a JSON array of blob locations.
+* ``--output-blob-storage-location``  -- a single JSON object.
+* ``--extras``                        -- a JSON object of per-workflow-type
+  custom fields. The schema is owned by each image (see ``ExtrasModel``).
+
+sara-thermal-reading is a single-image analyzer, so the input array must
+contain exactly one element. Anything else is a hard failure surfaced
+through Typer.
+"""
+
+import json
+from typing import List, Type, TypeVar
+
+import typer
+from pydantic import BaseModel, ValidationError
+
+from sara_thermal_reading.models.blob_storage_location import BlobStorageLocation
+
+ExtrasT = TypeVar("ExtrasT", bound=BaseModel)
+
+
+def parse_input_blob_storage_locations(value: str) -> List[BlobStorageLocation]:
+    try:
+        raw = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(
+            f"--input-blob-storage-locations is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(raw, list):
+        raise typer.BadParameter(
+            "--input-blob-storage-locations must be a JSON array of blob "
+            f"locations, got {type(raw).__name__}."
+        )
+
+    if len(raw) != 1:
+        raise typer.BadParameter(
+            "--input-blob-storage-locations must contain exactly one entry "
+            f"(sara-thermal-reading is a single-image analyzer); got {len(raw)}."
+        )
+
+    try:
+        return [BlobStorageLocation.model_validate(item) for item in raw]
+    except ValidationError as exc:
+        raise typer.BadParameter(
+            f"--input-blob-storage-locations entry is invalid: {exc}"
+        ) from exc
+
+
+def parse_output_blob_storage_location(value: str) -> BlobStorageLocation:
+    try:
+        raw = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(
+            f"--output-blob-storage-location is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(
+            "--output-blob-storage-location must be a JSON object, "
+            f"got {type(raw).__name__}."
+        )
+
+    try:
+        return BlobStorageLocation.model_validate(raw)
+    except ValidationError as exc:
+        raise typer.BadParameter(
+            f"--output-blob-storage-location is invalid: {exc}"
+        ) from exc
+
+
+def parse_extras(value: str, model: Type[ExtrasT]) -> ExtrasT:
+    try:
+        raw = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"--extras is not valid JSON: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(
+            f"--extras must be a JSON object, got {type(raw).__name__}."
+        )
+
+    try:
+        return model.model_validate(raw)
+    except ValidationError as exc:
+        raise typer.BadParameter(f"--extras is invalid: {exc}") from exc

--- a/sara_thermal_reading/main_thermal_workflow.py
+++ b/sara_thermal_reading/main_thermal_workflow.py
@@ -3,9 +3,9 @@ import logging
 import cv2
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from sara_thermal_reading.config.settings import settings
+from sara_thermal_reading.models.blob_storage_location import BlobStorageLocation
 
 logger = logging.getLogger(__name__)
 
@@ -23,24 +23,11 @@ from sara_thermal_reading.visualization.create_annotated_thermal_visualization i
     create_annotated_thermal_visualization,
 )
 
-
-class BlobStorageLocation(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
-    blob_container: str = Field(..., alias="blobContainer")
-    blob_name: str = Field(..., alias="blobName")
-
-    @field_validator("blob_container")
-    def validate_blob_container(cls, v: str) -> str:
-        if not v:
-            raise ValueError("blobContainer cannot be empty")
-        return v
-
-    @field_validator("blob_name")
-    def validate_blob_name(cls, v: str) -> str:
-        if not v:
-            raise ValueError("blobName cannot be empty")
-        return v
+__all__ = [
+    "BlobStorageLocation",
+    "process_thermal_image",
+    "run_thermal_reading_workflow",
+]
 
 
 def process_thermal_image(

--- a/sara_thermal_reading/models/blob_storage_location.py
+++ b/sara_thermal_reading/models/blob_storage_location.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class BlobStorageLocation(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    blob_container: str = Field(..., alias="blobContainer")
+    blob_name: str = Field(..., alias="blobName")
+
+    @field_validator("blob_container")
+    def validate_blob_container(cls, v: str) -> str:
+        if not v:
+            raise ValueError("blobContainer cannot be empty")
+        return v
+
+    @field_validator("blob_name")
+    def validate_blob_name(cls, v: str) -> str:
+        if not v:
+            raise ValueError("blobName cannot be empty")
+        return v

--- a/tests/test_cli_inputs.py
+++ b/tests/test_cli_inputs.py
@@ -1,0 +1,123 @@
+import json
+
+import pytest
+import typer
+from pydantic import BaseModel, ConfigDict
+
+from sara_thermal_reading.cli_inputs import (
+    parse_extras,
+    parse_input_blob_storage_locations,
+    parse_output_blob_storage_location,
+)
+from sara_thermal_reading.models.blob_storage_location import BlobStorageLocation
+
+
+class _ClosedExtras(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def _loc(container: str = "b", blob: str = "c") -> dict[str, str]:
+    return {
+        "blobContainer": container,
+        "blobName": blob,
+    }
+
+
+def test_parse_input_returns_single_blob_storage_location() -> None:
+    expected: list[dict[str, str]] = [
+        {
+            "blobContainer": "src-container",
+            "blobName": "src-blob.tiff",
+        }
+    ]
+    payload: str = json.dumps(expected)
+
+    result = parse_input_blob_storage_locations(payload)
+
+    assert len(result) == len(expected)
+    location: BlobStorageLocation = result[0]
+    assert location.blob_container == expected[0]["blobContainer"]
+    assert location.blob_name == expected[0]["blobName"]
+
+
+def test_parse_output_returns_blob_storage_location() -> None:
+    expected: dict[str, str] = {
+        "blobContainer": "dst-container",
+        "blobName": "dst-blob.png",
+    }
+    payload: str = json.dumps(expected)
+
+    result: BlobStorageLocation = parse_output_blob_storage_location(payload)
+
+    assert result.blob_container == expected["blobContainer"]
+    assert result.blob_name == expected["blobName"]
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message_fragment",
+    [
+        ("not json{", "valid JSON"),
+        (json.dumps({"blobContainer": "a"}), "JSON array"),
+        (json.dumps([]), "exactly one"),
+        (json.dumps([_loc(), _loc("d", "e")]), "exactly one"),
+        (json.dumps([{"blobContainer": "a"}]), None),
+    ],
+    ids=[
+        "malformed-json",
+        "object-instead-of-array",
+        "empty-array",
+        "multiple-entries",
+        "missing-required-field",
+    ],
+)
+def test_parse_input_rejects_invalid_payloads(
+    payload: str, expected_message_fragment: str | None
+) -> None:
+    with pytest.raises(typer.BadParameter, match=expected_message_fragment):
+        parse_input_blob_storage_locations(payload)
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message_fragment",
+    [
+        ("not json{", "valid JSON"),
+        (json.dumps([_loc()]), "JSON object"),
+        (json.dumps({"blobContainer": "a"}), None),
+    ],
+    ids=[
+        "malformed-json",
+        "array-instead-of-object",
+        "missing-required-field",
+    ],
+)
+def test_parse_output_rejects_invalid_payloads(
+    payload: str, expected_message_fragment: str | None
+) -> None:
+    with pytest.raises(typer.BadParameter, match=expected_message_fragment):
+        parse_output_blob_storage_location(payload)
+
+
+def test_parse_extras_returns_validated_model_instance() -> None:
+    result = parse_extras("{}", _ClosedExtras)
+
+    assert isinstance(result, _ClosedExtras)
+
+
+@pytest.mark.parametrize(
+    "payload, expected_message_fragment",
+    [
+        ("not json{", "valid JSON"),
+        (json.dumps([]), "JSON object"),
+        (json.dumps({"unexpected": "field"}), "invalid"),
+    ],
+    ids=[
+        "malformed-json",
+        "array-instead-of-object",
+        "unknown-key-rejected",
+    ],
+)
+def test_parse_extras_rejects_invalid_payloads(
+    payload: str, expected_message_fragment: str | None
+) -> None:
+    with pytest.raises(typer.BadParameter, match=expected_message_fragment):
+        parse_extras(payload, _ClosedExtras)


### PR DESCRIPTION
Aligns this analyzer with the new SARA / Argo contract. Companion to equinor/sara#363.

## Changes
- New CLI: `--input-blob-storage-locations`, `--output-blob-storage-location`, `--extras`. Replaces all previous flags
- `--input-blob-storage-locations` is a JSON array (single-input enforced for this analyzer)
- `--extras` is a JSON object (required, pass `'{}'` to skip). `referenceImageBlobStorageLocation` and `referencePolygonBlobStorageLocation` move into extras

## Linked PRs
- equinor/sara#363 — core SARA pipeline (drives this contract)
- equinor/analytics-infrastructure#282 — Argo template + Sensor alignment
- equinor/sara-anonymizer#74 — analyzer CLI + result file (depends on equinor/sara-anonymizer#72)
- equinor/sara-fence-detection#138 — analyzer CLI
- equinor/sara-constant-level-oiler#62 — analyzer CLI
- equinor/flotilla#2715 — MQTT consumer alignment
