### PR TITLE
Emit single result.json from thermal-reading CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,8 +59,12 @@ def run_thermal_reading(
             "'referencePolygonBlobStorageLocation'."
         ),
     ),
-    temperature_output_file: str = typer.Option(
-        "/tmp/temperature_output.txt", help="Temperature output file path"
+    result_output_file: str = typer.Option(
+        "/tmp/result.json",
+        help=(
+            "Path to write the workflow result JSON to. The file is created "
+            "after the workflow succeeds and contains 'temperature' (float)."
+        ),
     ),
 ) -> None:
     anonymized_location = parse_input_blob_storage_locations(
@@ -92,7 +96,7 @@ def run_thermal_reading(
                 visualized_location,
                 reference_image_location,
                 reference_polygon_location,
-                temperature_output_file,
+                result_output_file,
             )
         except Exception as e:
             span.record_exception(e)

--- a/sara_thermal_reading/main_thermal_workflow.py
+++ b/sara_thermal_reading/main_thermal_workflow.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import cv2
@@ -98,7 +99,7 @@ def run_thermal_reading_workflow(
     visualized_blob_storage_location: BlobStorageLocation,
     reference_image_blob_storage_location: BlobStorageLocation,
     reference_polygon_blob_storage_location: BlobStorageLocation,
-    temperature_output_file: str,
+    result_output_file: str,
 ) -> None:
 
     logger.info(f"Starting run thermal reading workflow")
@@ -171,6 +172,6 @@ def run_thermal_reading_workflow(
         f"Uploaded annotated thermal image to visualized storage account: {visualized_blob_storage_location.blob_container}/{visualized_blob_storage_location.blob_name}"
     )
 
-    with open(temperature_output_file, "w") as file:
-        file.write(str(temperature))
-        logger.info(f"Temperature: {temperature} written to {temperature_output_file}")
+    with open(result_output_file, "w") as file:
+        json.dump({"temperature": float(temperature)}, file)
+        logger.info(f"Temperature: {temperature} written to {result_output_file}")


### PR DESCRIPTION
Replace `--temperature-output-file` with `--result-output-file` that contains `{"temperature": <float>}`.

Aligns the analyzer output contract with `sara-anonymizer` and the cloe workflow so Argo templates can forward the result verbatim instead of composing JSON in YAML. Coordinated with corresponding `analytics-infrastructure` PR.